### PR TITLE
PLTFRS-15199: Do not crash when AWS resources are not found

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
-#! /bin/bash
-docker run --rm -v "$(pwd)":/go/src/github.com/AirVantage/overlord/ -w /go/src/github.com/AirVantage/overlord/ -e GOOS=darwin -e GOARCH=amd64 golang:1.13.8 sh -c "go mod download && go build -v -o overlord-darwin-amd64"
-docker run --rm -v "$(pwd)":/go/src/github.com/AirVantage/overlord/ -w /go/src/github.com/AirVantage/overlord/ -e GOOS=linux -e GOARCH=amd64 golang:1.13.8 sh -c "go mod download && go build -v -o overlord-linux-amd64"
+#!/bin/sh -x
+go_version=1.18.2
+repo=github.com/AirVantage/overlord
+docker run --rm -v "$(pwd)":/go/src/$repo -w /go/src/$repo -e GOOS=darwin -e GOARCH=amd64 golang:$go_version go build -o overlord-darwin-amd64
+docker run --rm -v "$(pwd)":/go/src/$repo -w /go/src/$repo -e GOOS=linux  -e GOARCH=amd64 golang:$go_version go build -o overlord-linux-amd64

--- a/pkg/lookable/asg.go
+++ b/pkg/lookable/asg.go
@@ -1,8 +1,6 @@
 package lookable
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -35,11 +33,11 @@ func (asg AutoScalingGroup) LookupIPs(ipv6 bool) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(resp1.Tags) == 0 {
+		return output, nil
+	}
 
 	asgID := resp1.Tags[0].ResourceId
-	if asgID == nil {
-		return nil, fmt.Errorf("could not find ASG '%s'", asg.String())
-	}
 
 	// Find the ASG instances
 	params2 := &autoscaling.DescribeAutoScalingGroupsInput{
@@ -50,7 +48,7 @@ func (asg AutoScalingGroup) LookupIPs(ipv6 bool) ([]string, error) {
 		return nil, err
 	}
 	if len(resp2.AutoScalingGroups) == 0 {
-		return nil, fmt.Errorf("could not find ASG with tag: '%s'", asg.String())
+		return output, nil
 	}
 
 	numInstances := len(resp2.AutoScalingGroups[0].Instances)

--- a/pkg/lookable/subnet.go
+++ b/pkg/lookable/subnet.go
@@ -1,8 +1,6 @@
 package lookable
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -37,7 +35,7 @@ func (s Subnet) LookupIPs(ipv6 bool) ([]string, error) {
 	}
 
 	if len(resp1.Subnets) == 0 {
-		return nil, fmt.Errorf("could not find subnet '%s'", s.String())
+		return output, nil
 	}
 
 	// Find the running instances


### PR DESCRIPTION
- make sure we do not access uninitialized []state groups
- do not return an error if a resource is not found or empty
- do not abort at startup if we cannot connect to syslog
- check for errors after toml encoding (found with staticcheck)