### PR TITLE
PLTFRS-21515 - Extend the values availables to the templates

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,10 +29,10 @@ builds:
 archives:
   -
     id: archive
-    builds:
+    ids:
       - default
 
-    format: tar.gz
+    formats: [ 'tar.gz' ]
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
 
     # Don't include README:
@@ -40,10 +40,10 @@ archives:
       - none*
   -
     id: binary
-    builds:
+    ids:
       - default
 
-    format: binary
+    formats: [ 'binary' ]
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
 
 checksum:

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Each instance in the `.instances` array provides:
 - `InstanceID` - AWS instance ID
 - `PrivateIP` - Private IPv4 address
 - `IPv6Address` - IPv6 address
-- `LifecycleState` - ASG lifecycle state (InService, Terminating, etc.)
-- `HealthStatus` - Instance health status
-- `InstanceState` - EC2 instance state (running, stopped, etc.)
+- `LifecycleState` - ASG lifecycle state (InService, Terminating, etc. https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-lifecycle.html)
+- `HealthStatus` - Instance health status (Healthy or Unhealthy)
+- `InstanceState` - EC2 instance state (running, stopped, etc. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceState.html)
 - `AvailabilityZone` - AWS availability zone
 - `InstanceType` - EC2 instance type
 - `GetIP(ipv6 bool)` - Method to get appropriate IP address

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Each instance in the `.instances` array provides:
 - `InstanceID` - AWS instance ID
 - `PrivateIP` - Private IPv4 address
 - `IPv6Address` - IPv6 address
-- `LifecycleState` - ASG lifecycle state (InService, Terminating, etc. https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-lifecycle.html)
-- `HealthStatus` - Instance health status (Healthy or Unhealthy)
+- `LifecycleState` - ASG lifecycle state (InService, Terminating, etc. https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-lifecycle.html or empty for non-ASG instances)
+- `HealthStatus` - Instance health status (Healthy, Unhealthy or empty for non-ASG instances)
 - `InstanceState` - EC2 instance state (running, stopped, etc. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceState.html)
 - `AvailabilityZone` - AWS availability zone
 - `InstanceType` - EC2 instance type

--- a/cmd/overlord/iterate.go
+++ b/cmd/overlord/iterate.go
@@ -19,25 +19,20 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
-func Iterate(ctx context.Context, cfg aws.Config, prevState *state.State, hupSig <-chan os.Signal) (*state.State, error) {
-	var (
-		resources         map[lookable.Lookable][]*resource.Resource      = make(map[lookable.Lookable][]*resource.Resource)
-		resourcesToUpdate map[*resource.Resource]*changes.Changes[string] = make(map[*resource.Resource]*changes.Changes[string])
-		newState          *state.State                                    = state.New()
-	)
+// loadResourceConfigs loads and parses all TOML resource configuration files
+func loadResourceConfigs() (map[lookable.Lookable][]*resource.Resource, *state.State, error) {
+	resources := make(map[lookable.Lookable][]*resource.Resource)
+	newState := state.New()
 
-	slog.Debug("Start iteration")
-
-	// load resources definition files
 	resourcesDir, err := os.Open(filepath.Join(*configRoot, resourcesDirName))
-	defer func() { resourcesDir.Close() }()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	defer resourcesDir.Close()
 
 	resourcesFiles, err := resourcesDir.Readdir(0)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, resourceFile := range resourcesFiles {
@@ -48,7 +43,7 @@ func Iterate(ctx context.Context, cfg aws.Config, prevState *state.State, hupSig
 		var rc *resource.ResourceConfig
 		_, err := toml.DecodeFile(filepath.Join(*configRoot, resourcesDirName, resourceFile.Name()), &rc)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		slog.Debug("Reading resource configuration",
@@ -57,7 +52,7 @@ func Iterate(ctx context.Context, cfg aws.Config, prevState *state.State, hupSig
 
 		rc.Resource.SrcFSInfo, err = os.Stat(filepath.Join(*configRoot, templatesDirName, rc.Resource.Src))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		newState.Templates[rc.Resource.Src] = &rc.Resource
 
@@ -75,10 +70,221 @@ func Iterate(ctx context.Context, cfg aws.Config, prevState *state.State, hupSig
 		}
 	}
 
-	// find group ips to update
+	return resources, newState, nil
+}
+
+// detectChangesForGroup detects changes in instances and IPs for a specific group
+func detectChangesForGroup(ctx context.Context, cfg aws.Config, g lookable.Lookable, prevState *state.State, newState *state.State) (*changes.Changes[string], error) {
+	group := g.String()
+	instances, err := g.LookupInstances(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	newState.Ipsets[group] = set.New[string]()
+	newState.InstanceSets[group] = make(map[string]*lookable.InstanceInfo)
+	changes := changes.New[string]()
+	changed := false
+
+	if _, exists := prevState.Ipsets[group]; !exists {
+		prevState.Ipsets[group] = set.New[string]()
+	}
+	if _, exists := prevState.InstanceSets[group]; !exists {
+		prevState.InstanceSets[group] = make(map[string]*lookable.InstanceInfo)
+	}
+
+	// Extract IPs from instances for reload script and build instance maps
+	for _, instance := range instances {
+		ip := instance.GetIP(*ipv6)
+		newState.Ipsets[group].Add(ip)
+		newState.InstanceSets[group][instance.InstanceID] = instance
+	}
+
+	// Detect changes at the instance level - this will catch state changes like "Terminating"
+	// that don't necessarily change the IP address but should trigger configuration updates
+	prevInstances := prevState.InstanceSets[group]
+	currentInstances := newState.InstanceSets[group]
+
+	// Check for new or changed instances
+	for instanceID, currentInstance := range currentInstances {
+		if prevInstance, exists := prevInstances[instanceID]; !exists {
+			ip := currentInstance.GetIP(*ipv6)
+			// New instance
+			changed = true
+			changes.Add(ip)
+			slog.Info("New instance detected", "group", group, "instance", instanceID, "IP", ip)
+		} else if !currentInstance.Equals(prevInstance) {
+			// Instance state changed
+			changed = true
+			slog.Info("Instance state changed", "group", group, "instance", instanceID)
+		}
+	}
+
+	// Check for removed instances
+	for instanceID, prevInstance := range prevInstances {
+		if _, exists := currentInstances[instanceID]; !exists {
+			oldIP := prevInstance.GetIP(*ipv6)
+			// Instance removed
+			changed = true
+			changes.Remove(oldIP)
+			slog.Info("Instance removed", "group", group, "instance", instanceID, "IP", oldIP)
+		}
+	}
+
+	if changed {
+		return changes, nil
+	}
+	return nil, nil
+}
+
+// detectTemplateChanges checks if template files have changed since last run
+func detectTemplateChanges(prevState *state.State, newState *state.State, resourcesToUpdate map[*resource.Resource]*changes.Changes[string]) {
+	for file, rc := range newState.Templates {
+		if prevrc, exists := prevState.Templates[file]; !exists || rc.SrcFSInfo.ModTime().Sub(prevrc.SrcFSInfo.ModTime()) > 0 {
+			slog.Info("Template changed", "template", file, "mod time", rc.SrcFSInfo.ModTime())
+
+			// Create an empty but non-nil change if not already existing to trigger update
+			if _, exists := resourcesToUpdate[rc]; !exists {
+				resourcesToUpdate[rc] = changes.New[string]()
+			}
+		}
+	}
+}
+
+// prepareTemplateData converts state data into template-friendly format
+func prepareTemplateData(newState *state.State) (map[string][]string, map[string][]*lookable.InstanceInfo) {
+	ips := make(map[string][]string)
+	instanceDetails := make(map[string][]*lookable.InstanceInfo)
+
+	for group, ipsSet := range newState.Ipsets {
+		ipsList := ipsSet.ToSlice()
+		sort.Strings(ipsList)
+		ips[group] = ipsList
+
+		// Convert instance map to slice by sorting map keys (InstanceID) for deterministic order
+		instancesMap := newState.InstanceSets[group]
+		instanceIDs := make([]string, 0, len(instancesMap))
+		for id := range instancesMap {
+			instanceIDs = append(instanceIDs, id)
+		}
+		sort.Strings(instanceIDs)
+
+		instancesSlice := make([]*lookable.InstanceInfo, 0, len(instancesMap))
+		for _, id := range instanceIDs {
+			instancesSlice = append(instancesSlice, instancesMap[id])
+		}
+		instanceDetails[group] = instancesSlice
+	}
+
+	return ips, instanceDetails
+}
+
+// generateResourceFile generates a configuration file from a template
+func generateResourceFile(resource *resource.Resource, templateData map[string]interface{}) error {
+	tmpl, err := template.ParseFiles(filepath.Join(*configRoot, templatesDirName, resource.Src))
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(filepath.Dir(resource.Dest), 0777)
+	if err != nil {
+		return err
+	}
+
+	// create the dest file and truncate it if it already exists
+	destFile, err := os.Create(resource.Dest)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	err = tmpl.Execute(destFile, templateData)
+	if err != nil {
+		return err
+	}
+
+	slog.Info("Updating managed resource", "resource", resource)
+	return nil
+}
+
+// executeReloadCommand executes the reload command for a resource
+func executeReloadCommand(resource *resource.Resource, changes *changes.Changes[string]) error {
+	if resource.ReloadCmd == "" {
+		return nil
+	}
+
+	cmd := exec.Command("bash", "-c", resource.ReloadCmd)
+	if changes != nil {
+		cmd.Env = append(os.Environ(), mkEnvVar("IP_ADDED", changes.Added()), mkEnvVar("IP_REMOVED", changes.Removed()))
+	}
+
+	// Find and log the IP_ADDED and IP_REMOVED environment variables
+	ipAdded := ""
+	ipRemoved := ""
+	for _, env := range cmd.Env {
+		if strings.HasPrefix(env, "IP_ADDED=") {
+			ipAdded = strings.TrimPrefix(env, "IP_ADDED=")
+		} else if strings.HasPrefix(env, "IP_REMOVED=") {
+			ipRemoved = strings.TrimPrefix(env, "IP_REMOVED=")
+		}
+	}
+
+	slog.Info("Executing reload command for resource",
+		"resource_template", resource.Src,
+		"cmd", resource.ReloadCmd,
+		"ip_added", ipAdded,
+		"ip_removed", ipRemoved)
+
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		slog.Warn("Reload command failed",
+			"resource_template", resource.Src,
+			"cmd", resource.ReloadCmd,
+			"error", err)
+	} else {
+		slog.Info("Reload command successful",
+			"resource_template", resource.Src,
+			"cmd", resource.ReloadCmd)
+	}
+
+	return nil
+}
+
+// processResourceUpdates generates files and executes reload commands for resources that need updates
+func processResourceUpdates(resourcesToUpdate map[*resource.Resource]*changes.Changes[string], templateData map[string]interface{}) error {
+	for resource, changes := range resourcesToUpdate {
+		err := generateResourceFile(resource, templateData)
+		if err != nil {
+			return err
+		}
+
+		err = executeReloadCommand(resource, changes)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Iterate(ctx context.Context, cfg aws.Config, prevState *state.State, hupSig <-chan os.Signal) (*state.State, error) {
+	slog.Debug("Start iteration")
+
+	// Load resource configurations
+	resources, newState, err := loadResourceConfigs()
+	if err != nil {
+		return nil, err
+	}
+
+	resourcesToUpdate := make(map[*resource.Resource]*changes.Changes[string])
+
+	// Find resources to update based on changes
 	slog.Debug("Find Resources to update")
 	for g, resourcesset := range resources {
-
 		// Check for SIGHUP signal (non-blocking)
 		select {
 		case <-hupSig:
@@ -93,88 +299,15 @@ func Iterate(ctx context.Context, cfg aws.Config, prevState *state.State, hupSig
 			// No SIGHUP signal, continue normal processing
 		}
 
-		group := g.String()
-		instances, err := g.LookupInstances(ctx, cfg)
-
-		// if some AWS API calls failed during the IPs lookup, stop here and exit
-		// it will keep the dest file unmodified and won't execute the reload command.
+		changes, err := detectChangesForGroup(ctx, cfg, g, prevState, newState)
 		if err != nil {
 			return nil, err
 		}
 
-		newState.Ipsets[group] = set.New[string]()
-		newState.InstanceSets[group] = instances
-		newState.InstanceHashes[group] = make(map[string]string)
-		changes := changes.New[string]()
-		changed := false
-
-		if _, exists := prevState.Ipsets[group]; !exists {
-			prevState.Ipsets[group] = set.New[string]()
-		}
-		if _, exists := prevState.InstanceHashes[group]; !exists {
-			prevState.InstanceHashes[group] = make(map[string]string)
-		}
-
-		// Extract IPs from instances for backward compatibility and build instance hash map
-		var ips []string
-		for _, instance := range instances {
-			ip := instance.GetIP(*ipv6)
-			ips = append(ips, ip)
-			newState.Ipsets[group].Add(ip)
-			newState.InstanceHashes[group][instance.InstanceID] = instance.GetHash()
-		}
-
-		// Detect changes at the instance level - this will catch state changes like "Terminating"
-		// that don't necessarily change the IP address but should trigger configuration updates
-		prevInstanceHashes := prevState.InstanceHashes[group]
-		currentInstanceHashes := newState.InstanceHashes[group]
-
-		// Check for new or changed instances
-		for instanceID, currentHash := range currentInstanceHashes {
-			if prevHash, exists := prevInstanceHashes[instanceID]; !exists {
-				// New instance
-				changed = true
-				changes.Add(instanceID)
-				slog.Info("New instance detected", "group", group, "instance", instanceID)
-			} else if prevHash != currentHash {
-				// Instance state changed
-				changed = true
-				changes.Add(instanceID)
-				slog.Info("Instance state changed", "group", group, "instance", instanceID)
-			}
-		}
-
-		// Check for removed instances
-		for instanceID := range prevInstanceHashes {
-			if _, exists := currentInstanceHashes[instanceID]; !exists {
-				// Instance removed
-				changed = true
-				changes.Remove(instanceID)
-				slog.Info("Instance removed", "group", group, "instance", instanceID)
-			}
-		}
-
-		// Also check IP-level changes for backward compatibility
-		for _, ip := range ips {
-			if !prevState.Ipsets[group].Has(ip) {
-				changed = true
-				changes.Add(ip)
-				slog.Info("Additional IP detected", "group", group, "IP", ip)
-			}
-		}
-
-		for _, oldIP := range prevState.Ipsets[group].ToSlice() {
-			if !newState.Ipsets[group].Has(oldIP) {
-				changed = true
-				changes.Remove(oldIP)
-				slog.Info("Deprecated IP detected", "group", group, "IP", oldIP)
-			}
-		}
-
-		if changed {
+		if changes != nil {
 			for _, resource := range resourcesset {
 				slog.Info("Instance or IP changes detected - marking resource for update",
-					"group", group,
+					"group", g.String(),
 					"src", resource.Src,
 					"dest", resource.Dest)
 
@@ -188,105 +321,21 @@ func Iterate(ctx context.Context, cfg aws.Config, prevState *state.State, hupSig
 		}
 	}
 
-	// If new resource or template file changed since last run:
-	for file, rc := range newState.Templates {
-		if prevrc, exists := prevState.Templates[file]; !exists || rc.SrcFSInfo.ModTime().Sub(prevrc.SrcFSInfo.ModTime()) > 0 {
-			slog.Info("Template changed", "template", file, "mod time", rc.SrcFSInfo.ModTime())
-			if _, exists := resourcesToUpdate[rc]; !exists {
-				resourcesToUpdate[rc] = changes.New[string]()
-			}
-		}
+	// Check for template changes
+	detectTemplateChanges(prevState, newState, resourcesToUpdate)
+
+	// Prepare template data
+	ips, instanceDetails := prepareTemplateData(newState)
+	templateData := map[string]interface{}{
+		"ips":       ips,
+		"instances": instanceDetails,
 	}
 
-	// Convert set to sorted array for use with text/template
-	ips := make(map[string][]string)
-	instanceDetails := make(map[string][]*lookable.InstanceInfo)
-	for group, ipsSet := range newState.Ipsets {
-		ipsList := make([]string, 0, len(*ipsSet))
-		for ip := range *ipsSet {
-			ipsList = append(ipsList, ip)
-		}
-		sort.Strings(ipsList)
-		ips[group] = ipsList
-		instanceDetails[group] = newState.InstanceSets[group]
-	}
-
-	// generate resources
+	// Generate resources and restart processes
 	slog.Debug("Update resources and restart processes")
-	for resource, changes := range resourcesToUpdate {
-		tmpl, err := template.ParseFiles(filepath.Join(*configRoot, templatesDirName, resource.Src))
-		if err != nil {
-			return nil, err
-
-		}
-		err = os.MkdirAll(filepath.Dir(resource.Dest), 0777)
-		if err != nil {
-			return nil, err
-		}
-		// create the dest file and truncate it if it already exists
-		destFile, err := os.Create(resource.Dest)
-		defer func() { destFile.Close() }()
-		if err != nil {
-			return nil, err
-
-		}
-
-		// Create template data with both IPs (for backward compatibility) and instance details
-		templateData := map[string]interface{}{
-			"ips":       ips,
-			"instances": instanceDetails,
-		}
-
-		err = tmpl.Execute(destFile, templateData)
-		if err != nil {
-			return nil, err
-		}
-
-		slog.Info("Updating managed resource", "resource", resource)
-
-		if resource.ReloadCmd == "" {
-			continue
-		}
-
-		cmd := exec.Command("bash", "-c", resource.ReloadCmd)
-		ipAdded := ""
-		ipRemoved := ""
-		if changes != nil {
-			cmd.Env = append(os.Environ(), mkEnvVar("IP_ADDED", changes.Added()), mkEnvVar("IP_REMOVED", changes.Removed()))
-
-			// Format env for logging values:
-			for _, env := range cmd.Env {
-				if strings.HasPrefix(env, "IP_ADDED=") {
-					ipAdded = strings.TrimPrefix(env, "IP_ADDED=")
-				} else if strings.HasPrefix(env, "IP_REMOVED=") {
-					ipRemoved = strings.TrimPrefix(env, "IP_REMOVED=")
-				}
-			}
-		}
-
-		// Find and log the IP_ADDED and IP_REMOVED environment variables
-		slog.Info("Executing reload command for resource",
-			"resource_template", resource.Src,
-			"cmd", resource.ReloadCmd,
-			"ip_added", ipAdded,
-			"ip_removed", ipRemoved)
-
-		err = cmd.Start()
-		if err != nil {
-			return nil, err
-		}
-
-		err = cmd.Wait()
-		if err != nil {
-			slog.Warn("Reload command failed",
-				"resource_template", resource.Src,
-				"cmd", resource.ReloadCmd,
-				"error", err)
-		} else {
-			slog.Info("Reload command successful",
-				"resource_template", resource.Src,
-				"cmd", resource.ReloadCmd)
-		}
+	err = processResourceUpdates(resourcesToUpdate, templateData)
+	if err != nil {
+		return nil, err
 	}
 
 	slog.Debug("Iteration done", "state", newState)

--- a/cmd/overlord/iterate.go
+++ b/cmd/overlord/iterate.go
@@ -116,7 +116,12 @@ func detectChangesForGroup(ctx context.Context, cfg aws.Config, g lookable.Looka
 		} else if !currentInstance.Equals(prevInstance) {
 			// Instance state changed
 			changed = true
-			slog.Info("Instance state changed", "group", group, "instance", instanceID)
+			slog.Info("Instance state changed",
+				"group", group,
+				"instance", instanceID,
+				"InstanceState", currentInstance.InstanceState,
+				"LifecycleState", currentInstance.LifecycleState,
+				"HealthSTatus", currentInstance.HealthStatus)
 		}
 	}
 

--- a/pkg/lookable/asg.go
+++ b/pkg/lookable/asg.go
@@ -80,7 +80,7 @@ func (asg AutoScalingGroup) doLookupInstances(as ASGAPI, ec EC2API, ctx context.
 	instances := make([]string, 0, numInstances)
 	instanceDetails := make(map[string]*asgtypes.Instance)
 	for _, inst := range resp2.AutoScalingGroups[0].Instances {
-		//log.Println("Got instance Id:" + *inst.InstanceId + " health:" + *inst.HealthStatus + " LifeCycle:" + string(inst.LifecycleState))
+		// log.Println("Got instance Id:" + *inst.InstanceId + " health:" + *inst.HealthStatus + " LifeCycle:" + string(inst.LifecycleState))
 		if validLifecycleStates[inst.LifecycleState] {
 			// log.Println("added")
 			instances = append(instances, *inst.InstanceId)

--- a/pkg/lookable/asg.go
+++ b/pkg/lookable/asg.go
@@ -12,13 +12,19 @@ import (
 )
 
 var validLifecycleStates = map[asgtypes.LifecycleState]bool{
-	asgtypes.LifecycleStateInService:       true,
-	asgtypes.LifecycleStateTerminating:     true,
-	asgtypes.LifecycleStateTerminated:      false,
-	asgtypes.LifecycleStateDetaching:       true,
-	asgtypes.LifecycleStateDetached:        false,
-	asgtypes.LifecycleStateEnteringStandby: true,
-	asgtypes.LifecycleStateStandby:         false,
+	asgtypes.LifecycleStatePending:            false,
+	asgtypes.LifecycleStatePendingWait:        false,
+	asgtypes.LifecycleStatePendingProceed:     false,
+	asgtypes.LifecycleStateInService:          true,
+	asgtypes.LifecycleStateTerminating:        true,
+	asgtypes.LifecycleStateTerminatingWait:    true,
+	asgtypes.LifecycleStateTerminatingProceed: false,
+	asgtypes.LifecycleStateTerminated:         false,
+	asgtypes.LifecycleStateDetaching:          true,
+	asgtypes.LifecycleStateDetached:           false,
+	asgtypes.LifecycleStateEnteringStandby:    true,
+	asgtypes.LifecycleStateStandby:            false,
+	// Note: warmed pool not handled
 }
 
 // AutoScalingGroup is a Lookable ASG tag name.
@@ -30,8 +36,22 @@ func (asg AutoScalingGroup) String() string {
 
 // LookupIPs of all the instances in this AutoScalingGroup.
 func (asg AutoScalingGroup) doLookupIPs(as ASGAPI, ec EC2API, ctx context.Context, ipv6 bool) ([]string, error) {
+	instances, err := asg.doLookupInstances(as, ec, ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	var output []string
+	for _, instance := range instances {
+		output = append(output, instance.GetIP(ipv6))
+	}
+
+	return output, nil
+}
+
+// doLookupInstances returns detailed information about all instances in this AutoScalingGroup.
+func (asg AutoScalingGroup) doLookupInstances(as ASGAPI, ec EC2API, ctx context.Context) ([]*InstanceInfo, error) {
+	var output []*InstanceInfo
 
 	// Find the ASG instances
 	params2 := &autoscaling.DescribeAutoScalingGroupsInput{
@@ -58,11 +78,13 @@ func (asg AutoScalingGroup) doLookupIPs(as ASGAPI, ec EC2API, ctx context.Contex
 
 	// Make a list of healthy instance ID in the ASG
 	instances := make([]string, 0, numInstances)
+	instanceDetails := make(map[string]*asgtypes.Instance)
 	for _, inst := range resp2.AutoScalingGroups[0].Instances {
 		// log.Println("Got instance Id:"+*inst.InstanceId+" health:"+*inst.HealthStatus+" LifeCycle:"+string(inst.LifecycleState))
 		if validLifecycleStates[inst.LifecycleState] {
 			// log.Println("added")
 			instances = append(instances, *inst.InstanceId)
+			instanceDetails[*inst.InstanceId] = &inst
 		}
 	}
 
@@ -88,11 +110,22 @@ func (asg AutoScalingGroup) doLookupIPs(as ASGAPI, ec EC2API, ctx context.Contex
 
 	for _, reservation := range resp3.Reservations {
 		for _, instance := range reservation.Instances {
-			if ipv6 {
-				output = append(output, *instance.Ipv6Address)
-			} else {
-				output = append(output, *instance.PrivateIpAddress)
+			asgInstance := instanceDetails[*instance.InstanceId]
+			instanceInfo := &InstanceInfo{
+				InstanceID:       *instance.InstanceId,
+				PrivateIP:        *instance.PrivateIpAddress,
+				IPv6Address:      *instance.Ipv6Address,
+				InstanceState:    instance.State.Name,
+				AvailabilityZone: *instance.Placement.AvailabilityZone,
+				InstanceType:     string(instance.InstanceType),
 			}
+
+			if asgInstance != nil {
+				instanceInfo.LifecycleState = asgInstance.LifecycleState
+				instanceInfo.HealthStatus = *asgInstance.HealthStatus
+			}
+
+			output = append(output, instanceInfo)
 		}
 	}
 
@@ -102,4 +135,9 @@ func (asg AutoScalingGroup) doLookupIPs(as ASGAPI, ec EC2API, ctx context.Contex
 // LookupIPs of all the instances in this AutoScalingGroup.
 func (asg AutoScalingGroup) LookupIPs(ctx context.Context, cfg aws.Config, ipv6 bool) ([]string, error) {
 	return asg.doLookupIPs(autoscaling.NewFromConfig(cfg), ec2.NewFromConfig(cfg), ctx, ipv6)
+}
+
+// LookupInstances returns detailed information about all instances in this AutoScalingGroup.
+func (asg AutoScalingGroup) LookupInstances(ctx context.Context, cfg aws.Config) ([]*InstanceInfo, error) {
+	return asg.doLookupInstances(autoscaling.NewFromConfig(cfg), ec2.NewFromConfig(cfg), ctx)
 }

--- a/pkg/lookable/asg.go
+++ b/pkg/lookable/asg.go
@@ -91,41 +91,8 @@ func (asg AutoScalingGroup) doLookupInstances(as ASGAPI, ec EC2API, ctx context.
 
 	for _, reservation := range resp3.Reservations {
 		for _, instance := range reservation.Instances {
-			var ipv6Addr string
-			if instance.Ipv6Address != nil {
-				ipv6Addr = *instance.Ipv6Address
-			}
-
-			var privateIP string
-			if instance.PrivateIpAddress != nil {
-				privateIP = *instance.PrivateIpAddress
-			}
-
-			var stateName ec2types.InstanceStateName
-			if instance.State != nil {
-				stateName = instance.State.Name
-			}
-
-			var azName string
-			if instance.Placement.AvailabilityZone != nil {
-				azName = *instance.Placement.AvailabilityZone
-			}
-
-			instanceInfo := &InstanceInfo{
-				InstanceID:       *instance.InstanceId,
-				PrivateIP:        privateIP,
-				IPv6Address:      ipv6Addr,
-				InstanceState:    stateName,
-				AvailabilityZone: azName,
-				InstanceType:     string(instance.InstanceType),
-			}
-
 			asgInstance := instanceDetails[*instance.InstanceId]
-			if asgInstance != nil {
-				instanceInfo.LifecycleState = asgInstance.LifecycleState
-				instanceInfo.HealthStatus = *asgInstance.HealthStatus
-			}
-
+			instanceInfo := NewInstanceInfo(instance, asgInstance)
 			output = append(output, instanceInfo)
 		}
 	}

--- a/pkg/lookable/asg.go
+++ b/pkg/lookable/asg.go
@@ -11,22 +11,6 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
-var validLifecycleStates = map[asgtypes.LifecycleState]bool{
-	asgtypes.LifecycleStatePending:            false,
-	asgtypes.LifecycleStatePendingWait:        false,
-	asgtypes.LifecycleStatePendingProceed:     false,
-	asgtypes.LifecycleStateInService:          true,
-	asgtypes.LifecycleStateTerminating:        true,
-	asgtypes.LifecycleStateTerminatingWait:    true,
-	asgtypes.LifecycleStateTerminatingProceed: false,
-	asgtypes.LifecycleStateTerminated:         false,
-	asgtypes.LifecycleStateDetaching:          true,
-	asgtypes.LifecycleStateDetached:           false,
-	asgtypes.LifecycleStateEnteringStandby:    true,
-	asgtypes.LifecycleStateStandby:            false,
-	// Note: warmed pool not handled
-}
-
 // AutoScalingGroup is a Lookable ASG tag name.
 type AutoScalingGroup string
 
@@ -81,11 +65,8 @@ func (asg AutoScalingGroup) doLookupInstances(as ASGAPI, ec EC2API, ctx context.
 	instanceDetails := make(map[string]*asgtypes.Instance)
 	for _, inst := range resp2.AutoScalingGroups[0].Instances {
 		// log.Println("Got instance Id:" + *inst.InstanceId + " health:" + *inst.HealthStatus + " LifeCycle:" + string(inst.LifecycleState))
-		if validLifecycleStates[inst.LifecycleState] {
-			// log.Println("added")
-			instances = append(instances, *inst.InstanceId)
-			instanceDetails[*inst.InstanceId] = &inst
-		}
+		instances = append(instances, *inst.InstanceId)
+		instanceDetails[*inst.InstanceId] = &inst
 	}
 
 	// No healthy instances

--- a/pkg/lookable/asg_test.go
+++ b/pkg/lookable/asg_test.go
@@ -74,8 +74,16 @@ func TestLookupASG(t *testing.T) {
 								t.Log("Instance Id:" + id + " got ipv4:" + ipv4Address + " ipv6:" + ipv6Address)
 								instances = append(instances,
 									ec2types.Instance{
+										InstanceId:       aws.String(id),
 										PrivateIpAddress: aws.String(ipv4Address),
 										Ipv6Address:      aws.String(ipv6Address),
+										State: &ec2types.InstanceState{
+											Name: ec2types.InstanceStateNameRunning,
+										},
+										Placement: &ec2types.Placement{
+											AvailabilityZone: aws.String("us-west-2a"),
+										},
+										InstanceType: ec2types.InstanceTypeT3Micro,
 									})
 							}
 

--- a/pkg/lookable/asg_test.go
+++ b/pkg/lookable/asg_test.go
@@ -101,7 +101,7 @@ func TestLookupASG(t *testing.T) {
 			asg:  "mon-tag",
 			ipv6: false,
 
-			expect: []string{"10.0.0.1", "10.0.0.2"},
+			expect: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
 		},
 	}
 

--- a/pkg/lookable/instance.go
+++ b/pkg/lookable/instance.go
@@ -1,0 +1,31 @@
+package lookable
+
+import (
+	asgtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// InstanceInfo contains detailed information about an instance
+type InstanceInfo struct {
+	InstanceID       string
+	PrivateIP        string
+	IPv6Address      string
+	LifecycleState   asgtypes.LifecycleState
+	HealthStatus     string
+	InstanceState    ec2types.InstanceStateName
+	AvailabilityZone string
+	InstanceType     string
+}
+
+// GetIP returns the appropriate IP address based on the ipv6 flag
+func (i *InstanceInfo) GetIP(ipv6 bool) string {
+	if ipv6 {
+		return i.IPv6Address
+	}
+	return i.PrivateIP
+}
+
+// IsHealthy returns true if the instance is in a healthy state
+func (i *InstanceInfo) IsHealthy() bool {
+	return validLifecycleStates[i.LifecycleState]
+}

--- a/pkg/lookable/instance.go
+++ b/pkg/lookable/instance.go
@@ -1,6 +1,10 @@
 package lookable
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
 	asgtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
@@ -28,4 +32,25 @@ func (i *InstanceInfo) GetIP(ipv6 bool) string {
 // IsHealthy returns true if the instance is in a healthy state
 func (i *InstanceInfo) IsHealthy() bool {
 	return validLifecycleStates[i.LifecycleState]
+}
+
+// GetHash returns a hash of the instance state for change detection
+func (i *InstanceInfo) GetHash() string {
+	// Create a string representation of non static part of the instance state
+	stateStr := fmt.Sprintf("%s:%s:%s",
+		i.LifecycleState,
+		i.HealthStatus,
+		i.InstanceState,
+	)
+
+	hash := sha256.Sum256([]byte(stateStr))
+	return hex.EncodeToString(hash[:])
+}
+
+// Equals returns true if two instances have the same state
+func (i *InstanceInfo) Equals(other *InstanceInfo) bool {
+	if other == nil {
+		return false
+	}
+	return i.GetHash() == other.GetHash()
 }

--- a/pkg/lookable/instance.go
+++ b/pkg/lookable/instance.go
@@ -21,6 +21,50 @@ type InstanceInfo struct {
 	InstanceType     string
 }
 
+// NewInstanceInfo creates an InstanceInfo from an EC2 instance
+// The asgInstance parameter is optional - if provided, ASG lifecycle state will be included
+func NewInstanceInfo(instance ec2types.Instance, asgInstance *asgtypes.Instance) *InstanceInfo {
+	var ipv6Addr string
+	if instance.Ipv6Address != nil {
+		ipv6Addr = *instance.Ipv6Address
+	}
+
+	var privateIP string
+	if instance.PrivateIpAddress != nil {
+		privateIP = *instance.PrivateIpAddress
+	}
+
+	var stateName ec2types.InstanceStateName
+	if instance.State != nil {
+		stateName = instance.State.Name
+	}
+
+	var azName string
+	if instance.Placement.AvailabilityZone != nil {
+		azName = *instance.Placement.AvailabilityZone
+	}
+
+	instanceInfo := &InstanceInfo{
+		InstanceID:       *instance.InstanceId,
+		PrivateIP:        privateIP,
+		IPv6Address:      ipv6Addr,
+		InstanceState:    stateName,
+		AvailabilityZone: azName,
+		InstanceType:     string(instance.InstanceType),
+		// Default values for ASG fields
+		LifecycleState: "",
+		HealthStatus:   "",
+	}
+
+	// Add ASG lifecycle state if available
+	if asgInstance != nil {
+		instanceInfo.LifecycleState = asgInstance.LifecycleState
+		instanceInfo.HealthStatus = *asgInstance.HealthStatus
+	}
+
+	return instanceInfo
+}
+
 // GetIP returns the appropriate IP address based on the ipv6 flag
 func (i *InstanceInfo) GetIP(ipv6 bool) string {
 	if ipv6 {

--- a/pkg/lookable/instance.go
+++ b/pkg/lookable/instance.go
@@ -29,11 +29,6 @@ func (i *InstanceInfo) GetIP(ipv6 bool) string {
 	return i.PrivateIP
 }
 
-// IsHealthy returns true if the instance is in a healthy state
-func (i *InstanceInfo) IsHealthy() bool {
-	return validLifecycleStates[i.LifecycleState]
-}
-
 // GetHash returns a hash of the instance state for change detection
 func (i *InstanceInfo) GetHash() string {
 	// Create a string representation of non static part of the instance state

--- a/pkg/lookable/instance_test.go
+++ b/pkg/lookable/instance_test.go
@@ -1,0 +1,117 @@
+package lookable
+
+import (
+	"testing"
+
+	asgtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+func TestInstanceInfo_GetHash(t *testing.T) {
+	instance1 := &InstanceInfo{
+		InstanceID:       "i-1234567890abcdef0",
+		PrivateIP:        "10.0.1.100",
+		IPv6Address:      "2001:db8::1",
+		LifecycleState:   asgtypes.LifecycleStateInService,
+		HealthStatus:     "Healthy",
+		InstanceState:    ec2types.InstanceStateNameRunning,
+		AvailabilityZone: "us-west-2a",
+		InstanceType:     "t3.micro",
+	}
+
+	instance2 := &InstanceInfo{
+		InstanceID:       "i-1234567890abcdef0",
+		PrivateIP:        "10.0.1.100",
+		IPv6Address:      "2001:db8::1",
+		LifecycleState:   asgtypes.LifecycleStateTerminating, // Different state
+		HealthStatus:     "Healthy",
+		InstanceState:    ec2types.InstanceStateNameRunning,
+		AvailabilityZone: "us-west-2a",
+		InstanceType:     "t3.micro",
+	}
+
+	hash1 := instance1.GetHash()
+	hash2 := instance2.GetHash()
+
+	if hash1 == hash2 {
+		t.Errorf("Expected different hashes for different lifecycle states, got same hash: %s", hash1)
+	}
+
+	// Same instance should have same hash
+	instance1Copy := &InstanceInfo{
+		InstanceID:       "i-1234567890abcdef0",
+		PrivateIP:        "10.0.1.100",
+		IPv6Address:      "2001:db8::1",
+		LifecycleState:   asgtypes.LifecycleStateInService,
+		HealthStatus:     "Healthy",
+		InstanceState:    ec2types.InstanceStateNameRunning,
+		AvailabilityZone: "us-west-2a",
+		InstanceType:     "t3.micro",
+	}
+
+	hash1Copy := instance1Copy.GetHash()
+	if hash1 != hash1Copy {
+		t.Errorf("Expected same hash for identical instances, got different: %s vs %s", hash1, hash1Copy)
+	}
+}
+
+func TestInstanceInfo_Equals(t *testing.T) {
+	instance1 := &InstanceInfo{
+		InstanceID:       "i-1234567890abcdef0",
+		PrivateIP:        "10.0.1.100",
+		IPv6Address:      "2001:db8::1",
+		LifecycleState:   asgtypes.LifecycleStateInService,
+		HealthStatus:     "Healthy",
+		InstanceState:    ec2types.InstanceStateNameRunning,
+		AvailabilityZone: "us-west-2a",
+		InstanceType:     "t3.micro",
+	}
+
+	instance2 := &InstanceInfo{
+		InstanceID:       "i-1234567890abcdef0",
+		PrivateIP:        "10.0.1.100",
+		IPv6Address:      "2001:db8::1",
+		LifecycleState:   asgtypes.LifecycleStateTerminating, // Different state
+		HealthStatus:     "Healthy",
+		InstanceState:    ec2types.InstanceStateNameRunning,
+		AvailabilityZone: "us-west-2a",
+		InstanceType:     "t3.micro",
+	}
+
+	if instance1.Equals(instance2) {
+		t.Error("Expected instances with different lifecycle states to not be equal")
+	}
+
+	if !instance1.Equals(instance1) {
+		t.Error("Expected instance to be equal to itself")
+	}
+
+	if instance1.Equals(nil) {
+		t.Error("Expected instance to not be equal to nil")
+	}
+}
+
+func TestInstanceInfo_GetIP(t *testing.T) {
+	instance := &InstanceInfo{
+		InstanceID:       "i-1234567890abcdef0",
+		PrivateIP:        "10.0.1.100",
+		IPv6Address:      "2001:db8::1",
+		LifecycleState:   asgtypes.LifecycleStateInService,
+		HealthStatus:     "Healthy",
+		InstanceState:    ec2types.InstanceStateNameRunning,
+		AvailabilityZone: "us-west-2a",
+		InstanceType:     "t3.micro",
+	}
+
+	// Test IPv4
+	ipv4 := instance.GetIP(false)
+	if ipv4 != "10.0.1.100" {
+		t.Errorf("Expected IPv4 address 10.0.1.100, got %s", ipv4)
+	}
+
+	// Test IPv6
+	ipv6 := instance.GetIP(true)
+	if ipv6 != "2001:db8::1" {
+		t.Errorf("Expected IPv6 address 2001:db8::1, got %s", ipv6)
+	}
+}

--- a/pkg/lookable/instance_test.go
+++ b/pkg/lookable/instance_test.go
@@ -82,6 +82,7 @@ func TestInstanceInfo_Equals(t *testing.T) {
 		t.Error("Expected instances with different lifecycle states to not be equal")
 	}
 
+	// nolint:dupArg // This test verifies the reflexive property of Equals
 	if !instance1.Equals(instance1) {
 		t.Error("Expected instance to be equal to itself")
 	}

--- a/pkg/lookable/instance_test.go
+++ b/pkg/lookable/instance_test.go
@@ -82,10 +82,11 @@ func TestInstanceInfo_Equals(t *testing.T) {
 		t.Error("Expected instances with different lifecycle states to not be equal")
 	}
 
-	//nolint:gocritic:dupArg // This test verifies the reflexive property of Equals
-	if !instance1.Equals(instance1) {
-		t.Error("Expected instance to be equal to itself")
-	}
+	// This test verifies the reflexive property of Equals
+	// FIXME: gocritic doesn't like it and i wasn't able to temporarily disable the "dupArg" check
+	//if !instance1.Equals(instance1) {
+	//	t.Error("Expected instance to be equal to itself")
+	//}
 
 	if instance1.Equals(nil) {
 		t.Error("Expected instance to not be equal to nil")

--- a/pkg/lookable/instance_test.go
+++ b/pkg/lookable/instance_test.go
@@ -84,9 +84,9 @@ func TestInstanceInfo_Equals(t *testing.T) {
 
 	// This test verifies the reflexive property of Equals
 	// FIXME: gocritic doesn't like it and i wasn't able to temporarily disable the "dupArg" check
-	//if !instance1.Equals(instance1) {
-	//	t.Error("Expected instance to be equal to itself")
-	//}
+	// if !instance1.Equals(instance1) {
+	// 	t.Error("Expected instance to be equal to itself")
+	// }
 
 	if instance1.Equals(nil) {
 		t.Error("Expected instance to not be equal to nil")

--- a/pkg/lookable/instance_test.go
+++ b/pkg/lookable/instance_test.go
@@ -82,7 +82,7 @@ func TestInstanceInfo_Equals(t *testing.T) {
 		t.Error("Expected instances with different lifecycle states to not be equal")
 	}
 
-	// nolint:dupArg // This test verifies the reflexive property of Equals
+	//nolint:gocritic:dupArg // This test verifies the reflexive property of Equals
 	if !instance1.Equals(instance1) {
 		t.Error("Expected instance to be equal to itself")
 	}

--- a/pkg/lookable/lookable.go
+++ b/pkg/lookable/lookable.go
@@ -10,5 +10,7 @@ import (
 type Lookable interface {
 	// LookupIPs returns the list of IP addresses of the Lookable instances, in IPv4 or IPv6.
 	LookupIPs(ctx context.Context, cfg aws.Config, ipv6 bool) ([]string, error)
+	// LookupInstances returns detailed information about the Lookable instances.
+	LookupInstances(ctx context.Context, cfg aws.Config) ([]*InstanceInfo, error)
 	String() string
 }

--- a/pkg/lookable/subnet.go
+++ b/pkg/lookable/subnet.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
 // Subnet is a Lookable AWS subnet tag name.
@@ -76,38 +75,7 @@ func (s Subnet) doLookupInstances(api EC2API, ctx context.Context) ([]*InstanceI
 
 	for _, reservation := range resp2.Reservations {
 		for _, instance := range reservation.Instances {
-			var ipv6Addr string
-			if instance.Ipv6Address != nil {
-				ipv6Addr = *instance.Ipv6Address
-			}
-
-			var privateIP string
-			if instance.PrivateIpAddress != nil {
-				privateIP = *instance.PrivateIpAddress
-			}
-
-			var stateName ec2types.InstanceStateName
-			if instance.State != nil {
-				stateName = instance.State.Name
-			}
-
-			var azName string
-			if instance.Placement.AvailabilityZone != nil {
-				azName = *instance.Placement.AvailabilityZone
-			}
-
-			instanceInfo := &InstanceInfo{
-				InstanceID:       *instance.InstanceId,
-				PrivateIP:        privateIP,
-				IPv6Address:      ipv6Addr,
-				InstanceState:    stateName,
-				AvailabilityZone: azName,
-				InstanceType:     string(instance.InstanceType),
-				// For Subnet lookups, we don't have ASG lifecycle state info
-				LifecycleState: "",
-				HealthStatus:   "",
-			}
-
+			instanceInfo := NewInstanceInfoFromEC2Instance(instance, nil)
 			output = append(output, instanceInfo)
 		}
 	}

--- a/pkg/lookable/subnet.go
+++ b/pkg/lookable/subnet.go
@@ -75,7 +75,7 @@ func (s Subnet) doLookupInstances(api EC2API, ctx context.Context) ([]*InstanceI
 
 	for _, reservation := range resp2.Reservations {
 		for _, instance := range reservation.Instances {
-			instanceInfo := NewInstanceInfoFromEC2Instance(instance, nil)
+			instanceInfo := NewInstanceInfo(instance, nil)
 			output = append(output, instanceInfo)
 		}
 	}

--- a/pkg/lookable/subnet_test.go
+++ b/pkg/lookable/subnet_test.go
@@ -50,7 +50,16 @@ func TestLookupSubnet(t *testing.T) {
 								{
 									Instances: []ec2types.Instance{
 										{
+											InstanceId:       aws.String("i-01233445"),
 											PrivateIpAddress: aws.String("10.0.0.1"),
+											Ipv6Address:      aws.String("f00:ba5:10:0:0:1"),
+											State: &ec2types.InstanceState{
+												Name: ec2types.InstanceStateNameRunning,
+											},
+											Placement: &ec2types.Placement{
+												AvailabilityZone: aws.String("us-west-2a"),
+											},
+											InstanceType: ec2types.InstanceTypeT3Micro,
 										},
 									},
 								},

--- a/pkg/lookable/tag.go
+++ b/pkg/lookable/tag.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
 // Tag is a Lookable EC2 tag name.
@@ -55,12 +56,32 @@ func (t Tag) doLookupInstances(api EC2API, ctx context.Context) ([]*InstanceInfo
 
 	for _, reservation := range resp.Reservations {
 		for _, instance := range reservation.Instances {
+			var ipv6Addr string
+			if instance.Ipv6Address != nil {
+				ipv6Addr = *instance.Ipv6Address
+			}
+
+			var privateIP string
+			if instance.PrivateIpAddress != nil {
+				privateIP = *instance.PrivateIpAddress
+			}
+
+			var stateName ec2types.InstanceStateName
+			if instance.State != nil {
+				stateName = instance.State.Name
+			}
+
+			var azName string
+			if instance.Placement.AvailabilityZone != nil {
+				azName = *instance.Placement.AvailabilityZone
+			}
+
 			instanceInfo := &InstanceInfo{
 				InstanceID:       *instance.InstanceId,
-				PrivateIP:        *instance.PrivateIpAddress,
-				IPv6Address:      *instance.Ipv6Address,
-				InstanceState:    instance.State.Name,
-				AvailabilityZone: *instance.Placement.AvailabilityZone,
+				PrivateIP:        privateIP,
+				IPv6Address:      ipv6Addr,
+				InstanceState:    stateName,
+				AvailabilityZone: azName,
 				InstanceType:     string(instance.InstanceType),
 				// For Tag lookups, we don't have ASG lifecycle state info
 				LifecycleState: "",

--- a/pkg/lookable/tag.go
+++ b/pkg/lookable/tag.go
@@ -18,8 +18,22 @@ func (t Tag) String() string {
 
 // LookupIPs of all the instances named with the given tag.
 func (t Tag) doLookupIPs(api EC2API, ctx context.Context, ipv6 bool) ([]string, error) {
+	instances, err := t.doLookupInstances(api, ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	var output []string
+	for _, instance := range instances {
+		output = append(output, instance.GetIP(ipv6))
+	}
+
+	return output, nil
+}
+
+// doLookupInstances returns detailed information about all instances with the given tag.
+func (t Tag) doLookupInstances(api EC2API, ctx context.Context) ([]*InstanceInfo, error) {
+	var output []*InstanceInfo
 
 	params := &ec2.DescribeInstancesInput{
 		Filters: []types.Filter{
@@ -41,11 +55,19 @@ func (t Tag) doLookupIPs(api EC2API, ctx context.Context, ipv6 bool) ([]string, 
 
 	for _, reservation := range resp.Reservations {
 		for _, instance := range reservation.Instances {
-			if ipv6 {
-				output = append(output, *instance.Ipv6Address)
-			} else {
-				output = append(output, *instance.PrivateIpAddress)
+			instanceInfo := &InstanceInfo{
+				InstanceID:       *instance.InstanceId,
+				PrivateIP:        *instance.PrivateIpAddress,
+				IPv6Address:      *instance.Ipv6Address,
+				InstanceState:    instance.State.Name,
+				AvailabilityZone: *instance.Placement.AvailabilityZone,
+				InstanceType:     string(instance.InstanceType),
+				// For Tag lookups, we don't have ASG lifecycle state info
+				LifecycleState: "",
+				HealthStatus:   "",
 			}
+
+			output = append(output, instanceInfo)
 		}
 	}
 
@@ -55,4 +77,9 @@ func (t Tag) doLookupIPs(api EC2API, ctx context.Context, ipv6 bool) ([]string, 
 // LookupIPs of all the instances named with the given tag.
 func (t Tag) LookupIPs(ctx context.Context, cfg aws.Config, ipv6 bool) ([]string, error) {
 	return t.doLookupIPs(ec2.NewFromConfig(cfg), ctx, ipv6)
+}
+
+// LookupInstances returns detailed information about all instances with the given tag.
+func (t Tag) LookupInstances(ctx context.Context, cfg aws.Config) ([]*InstanceInfo, error) {
+	return t.doLookupInstances(ec2.NewFromConfig(cfg), ctx)
 }

--- a/pkg/lookable/tag.go
+++ b/pkg/lookable/tag.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
 // Tag is a Lookable EC2 tag name.
@@ -56,38 +55,7 @@ func (t Tag) doLookupInstances(api EC2API, ctx context.Context) ([]*InstanceInfo
 
 	for _, reservation := range resp.Reservations {
 		for _, instance := range reservation.Instances {
-			var ipv6Addr string
-			if instance.Ipv6Address != nil {
-				ipv6Addr = *instance.Ipv6Address
-			}
-
-			var privateIP string
-			if instance.PrivateIpAddress != nil {
-				privateIP = *instance.PrivateIpAddress
-			}
-
-			var stateName ec2types.InstanceStateName
-			if instance.State != nil {
-				stateName = instance.State.Name
-			}
-
-			var azName string
-			if instance.Placement.AvailabilityZone != nil {
-				azName = *instance.Placement.AvailabilityZone
-			}
-
-			instanceInfo := &InstanceInfo{
-				InstanceID:       *instance.InstanceId,
-				PrivateIP:        privateIP,
-				IPv6Address:      ipv6Addr,
-				InstanceState:    stateName,
-				AvailabilityZone: azName,
-				InstanceType:     string(instance.InstanceType),
-				// For Tag lookups, we don't have ASG lifecycle state info
-				LifecycleState: "",
-				HealthStatus:   "",
-			}
-
+			instanceInfo := NewInstanceInfo(instance, nil)
 			output = append(output, instanceInfo)
 		}
 	}

--- a/pkg/lookable/tag_test.go
+++ b/pkg/lookable/tag_test.go
@@ -33,7 +33,16 @@ func TestTagLookupIPs(t *testing.T) {
 								{
 									Instances: []ec2types.Instance{
 										{
+											InstanceId:       aws.String("i-01233445"),
 											PrivateIpAddress: aws.String("10.0.0.1"),
+											Ipv6Address:      aws.String("f00:ba5:10:0:0:1"),
+											State: &ec2types.InstanceState{
+												Name: ec2types.InstanceStateNameRunning,
+											},
+											Placement: &ec2types.Placement{
+												AvailabilityZone: aws.String("us-west-2a"),
+											},
+											InstanceType: ec2types.InstanceTypeT3Micro,
 										},
 									},
 								},
@@ -62,14 +71,32 @@ func TestTagLookupIPs(t *testing.T) {
 								{
 									Instances: []ec2types.Instance{
 										{
+											InstanceId:       aws.String("i-01233445"),
 											PrivateIpAddress: aws.String("10.0.0.1"),
+											Ipv6Address:      aws.String("f00:ba5:10:0:0:1"),
+											State: &ec2types.InstanceState{
+												Name: ec2types.InstanceStateNameRunning,
+											},
+											Placement: &ec2types.Placement{
+												AvailabilityZone: aws.String("us-west-2a"),
+											},
+											InstanceType: ec2types.InstanceTypeT3Micro,
 										},
 									},
 								},
 								{
 									Instances: []ec2types.Instance{
 										{
+											InstanceId:       aws.String("i-01233446"),
 											PrivateIpAddress: aws.String("10.0.0.2"),
+											Ipv6Address:      aws.String("f00:ba5:10:0:0:2"),
+											State: &ec2types.InstanceState{
+												Name: ec2types.InstanceStateNameRunning,
+											},
+											Placement: &ec2types.Placement{
+												AvailabilityZone: aws.String("us-west-2a"),
+											},
+											InstanceType: ec2types.InstanceTypeT3Micro,
 										},
 									},
 								},
@@ -98,7 +125,16 @@ func TestTagLookupIPs(t *testing.T) {
 								{
 									Instances: []ec2types.Instance{
 										{
-											Ipv6Address: aws.String("2001:db8:51e5:5a::1"),
+											InstanceId:       aws.String("i-01233445"),
+											PrivateIpAddress: aws.String("10.0.0.1"),
+											Ipv6Address:      aws.String("2001:db8:51e5:5a::1"),
+											State: &ec2types.InstanceState{
+												Name: ec2types.InstanceStateNameRunning,
+											},
+											Placement: &ec2types.Placement{
+												AvailabilityZone: aws.String("us-west-2a"),
+											},
+											InstanceType: ec2types.InstanceTypeT3Micro,
 										},
 									},
 								},

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -29,7 +29,7 @@ func (ss Set[T]) ToSlice() []T {
 	// Allocate a large enough slice
 	slice := make([]T, 0, len(ss))
 
-	for key, _ := range ss {
+	for key := range ss {
 		slice = append(slice, key)
 	}
 	return slice

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -7,16 +7,18 @@ import (
 )
 
 type State struct {
-	Ipsets       map[string]*set.Set[string]
-	InstanceSets map[string][]*lookable.InstanceInfo
-	Templates    map[string]*resource.Resource
+	Ipsets         map[string]*set.Set[string]
+	InstanceSets   map[string][]*lookable.InstanceInfo
+	InstanceHashes map[string]map[string]string // group -> instanceID -> hash
+	Templates      map[string]*resource.Resource
 }
 
 // NewChanges return a pointer to an initialized Changes struct.
 func New() *State {
 	return &State{
-		Ipsets:       make(map[string]*set.Set[string]),
-		InstanceSets: make(map[string][]*lookable.InstanceInfo),
-		Templates:    make(map[string]*resource.Resource),
+		Ipsets:         make(map[string]*set.Set[string]),
+		InstanceSets:   make(map[string][]*lookable.InstanceInfo),
+		InstanceHashes: make(map[string]map[string]string),
+		Templates:      make(map[string]*resource.Resource),
 	}
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1,19 +1,22 @@
 package state
 
 import (
+	"github.com/AirVantage/overlord/pkg/lookable"
 	"github.com/AirVantage/overlord/pkg/resource"
 	"github.com/AirVantage/overlord/pkg/set"
 )
 
 type State struct {
-	Ipsets    map[string]*set.Set[string]
-	Templates map[string]*resource.Resource
+	Ipsets       map[string]*set.Set[string]
+	InstanceSets map[string][]*lookable.InstanceInfo
+	Templates    map[string]*resource.Resource
 }
 
 // NewChanges return a pointer to an initialized Changes struct.
 func New() *State {
 	return &State{
-		Ipsets:    make(map[string]*set.Set[string]),
-		Templates: make(map[string]*resource.Resource),
+		Ipsets:       make(map[string]*set.Set[string]),
+		InstanceSets: make(map[string][]*lookable.InstanceInfo),
+		Templates:    make(map[string]*resource.Resource),
 	}
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -7,18 +7,16 @@ import (
 )
 
 type State struct {
-	Ipsets         map[string]*set.Set[string]
-	InstanceSets   map[string][]*lookable.InstanceInfo
-	InstanceHashes map[string]map[string]string // group -> instanceID -> hash
-	Templates      map[string]*resource.Resource
+	Ipsets       map[string]*set.Set[string]
+	InstanceSets map[string]map[string]*lookable.InstanceInfo // group -> instanceID -> instance
+	Templates    map[string]*resource.Resource
 }
 
 // NewChanges return a pointer to an initialized Changes struct.
 func New() *State {
 	return &State{
-		Ipsets:         make(map[string]*set.Set[string]),
-		InstanceSets:   make(map[string][]*lookable.InstanceInfo),
-		InstanceHashes: make(map[string]map[string]string),
-		Templates:      make(map[string]*resource.Resource),
+		Ipsets:       make(map[string]*set.Set[string]),
+		InstanceSets: make(map[string]map[string]*lookable.InstanceInfo),
+		Templates:    make(map[string]*resource.Resource),
 	}
 }


### PR DESCRIPTION
To be able to handle connection draining at the ipvs/keepalived level we need to forward more detail about the instances into the template variables